### PR TITLE
Ensure collection permalinks are correctly generated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ defaults:
 collections:
   pages:
     output: true
-    permalink: /:path
+    permalink: /:path/
 
 permalink: pretty
 


### PR DESCRIPTION
I currently get loads of 404s using the config on `main` because, in a prior PR, the trailing `/` was removed from the collection permalink path config.

This reintroduces that trailing slash for collections only - `index` files are rendered without the trailing `/`.