### PR TITLE
Local server rendering hack

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ defaults:
 collections:
   pages:
     output: true
-    permalink: /:path/
+    permalink: /:path
 
 permalink: pretty
 

--- a/http_server.go
+++ b/http_server.go
@@ -3,10 +3,36 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
+type dirWithFallback struct {
+	http.Dir
+}
+
+var _ http.FileSystem = (*dirWithFallback)(nil)
+
+func (d *dirWithFallback) Open(name string) (http.File, error) {
+	if strings.HasSuffix(name, ".md") {
+		f, err := d.Dir.Open(name[:len(name)-3] + ".html")
+		if err == nil {
+			return f, nil
+		}
+	}
+
+	f, err := d.Dir.Open(name)
+	if err != nil {
+		f, err := d.Dir.Open(name + ".html")
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+	return f, nil
+}
+
 func main() {
-	h := http.FileServer(http.Dir("./_site"))
+	h := http.FileServer(&dirWithFallback{http.Dir("./_site")})
 	http.ListenAndServe(":8088", h)
 	fmt.Printf("Serving HTTP on 0.0.0.0 port 8088 ...\n")
 }


### PR DESCRIPTION
Reverts the change in d3d69b633eb98572d74962b10924f2c78f65595c and applies a silly hack to the local server to force it to render the site and its links correctly. Specifically:

 - If a URL ends in `.md`, it automatically tries to instead render the same file with a `.html` suffix.
- If a URL fails to render, it attempts to append `.html` to the filename.

Not intended to be merged - merely illustrative of how we could use web server tricks to solve the current rendering issues with Jekyll.