### PR TITLE
Revert "Replacing local server (go) with Jekyll docker to serve website locally"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,11 @@ versions-data:
 	done < VERSIONS
 .PHONY: versions-data
 
-# This builds the documentation site for cometbft (docs.cometbft.com)
-serve: versions-data
-	@echo "---> Preparing to host documentation site locally"
-	@echo "---> This might take a few seconds..."
-	@echo "---> If the site was not built with 'make build', this will take a bit longer..."
-	@docker run -it --rm -p 8088:8088 --volume ${PWD}:/srv/jekyll jekyll/builder:stable \
-	/bin/bash -c 'cd /srv/jekyll/ && jekyll serve --incremental --port 8088'
-.PHONY: build
+# Serve the built site from the _site folder
+serve:
+	@echo "---> Running documentation site at http://localhost:8088"
+	@go run http_server.go
+.PHONY: serve
 
 clean:
 	@echo "---> Deleting all previous build artifacts"

--- a/README.md
+++ b/README.md
@@ -75,22 +75,10 @@ If you want to run the site locally you can run the follow command:
 make serve
 ```
 
-This will run a docker container with Jekyll to host the website locally. 
+This will run a local HTTP server (based on Golang):
 
 ```
----> Preparing to host documentation site locally
----> This might take a few seconds...
----> If the site was not built with 'make build', this will take a bit longer...
-...
- Auto-regeneration: enabled for '/srv/jekyll'
-    Server address: http://0.0.0.0:8088/
-  Server running... press ctrl-c to stop.
-
+Running documentation site at http://localhost:8088
 ```
 
-Running it with Jekyll offers hot-reloading and any modifications to local files 
-(e.g. '.md' documents will automatically rebuild the website and changes will show in the browser)
-
-Navigate to `http://0.0.0.0:8088` to see the website in your local browser.
-
-> **Note**: the `make build` and `make serve` assumes you have [Docker](https://www.docker.com/) properly installed in your machine.
+Navigate to `http://localhost:8088` to see the website in your local browser.

--- a/http_server.go
+++ b/http_server.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	h := http.FileServer(http.Dir("./_site"))
+	http.ListenAndServe(":8088", h)
+	fmt.Printf("Serving HTTP on 0.0.0.0 port 8088 ...\n")
+}


### PR DESCRIPTION
Reverts cometbft/cometbft-docs#28 in order to ensure works well on Apple M1