### PR TITLE
Logic to hardcode the RPC nav link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -95,10 +95,7 @@
       </li>
     {% endif %}
   {% endfor %}
-  <li class="
-            TreeMenu-item
-            js-tree-menu-parent-item
-            has-children">
+  <li class="TreeMenu-item js-tree-menu-parent-item">
     <a class="TreeMenu-button js-tree-menu-toggle-button" href="/{{ currentVersion }}/rpc">
       RPC
     </a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,3 @@
-{% assign currentVersion = site.data.default_version.output_path %}
-
 {% assign lastSixCharsOfPageUrl = page.url | slice: -6, 6 %}
 
 {% if lastSixCharsOfPageUrl == '/index' %}
@@ -96,7 +94,7 @@
     {% endif %}
   {% endfor %}
   <li class="TreeMenu-item js-tree-menu-parent-item">
-    <a class="TreeMenu-button js-tree-menu-toggle-button" href="/{{ currentVersion }}/rpc">
+    <a class="TreeMenu-button js-tree-menu-toggle-button" href="{{ include.path }}/rpc">
       RPC
     </a>
   </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,5 @@
+{% assign currentVersion = site.data.default_version.output_path %}
+
 {% assign lastSixCharsOfPageUrl = page.url | slice: -6, 6 %}
 
 {% if lastSixCharsOfPageUrl == '/index' %}
@@ -93,4 +95,12 @@
       </li>
     {% endif %}
   {% endfor %}
+  <li class="
+            TreeMenu-item
+            js-tree-menu-parent-item
+            has-children">
+    <a class="TreeMenu-button js-tree-menu-toggle-button" href="/{{ currentVersion }}/rpc">
+      RPC
+    </a>
+  </li>
 </ul>


### PR DESCRIPTION
Implemented logic to show a `RPC` link in the left navigation that is not based on pages front mater but hard coded logic in `_includes\nav.html`