### PR TITLE
Update version suffix to remove RC number

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,3 +1,3 @@
 main      main        false
-v0.37.x   v0.37-rc2   true
+v0.37.x   v0.37-rc    true
 v0.34.x   v0.34       true


### PR DESCRIPTION
This should make it easier/quicker for us to update for any further RC's.