### PR TITLE
Prepare for v0.37.0 release

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,3 +1,3 @@
 main      main        false
-v0.37.x   v0.37-rc    true
 v0.34.x   v0.34       true
+v0.37.x   v0.37       true


### PR DESCRIPTION
Updates `VERSIONS` to:
1. Render the `v0.37.x` branch's docs to `/v0.37` instead of `/v0.37-rc`
2. Redirect users from <https://docs.cometbft.com> to <https://docs.cometbft.com/v0.37/> by default (instead of the v0.34 docs).