### PR TITLE
Render v0.38.x branch documentation

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,3 +1,4 @@
 main      main        false
+v0.38.x   v0.38       false
 v0.34.x   v0.34       true
 v0.37.x   v0.37       true


### PR DESCRIPTION
Partially addresses cometbft/cometbft#595

Renders the new `v0.38.x` branch's documentation under https://docs.cometbft.com/v0.38/ (once merged), but does not yet list in the version dropdown selector. It still also keeps the v0.37 docs as the default landing page when going to https://docs.cometbft.com.

We will list this in the version dropdown selector when we're ready to cut the final v0.38.0 release.