### PR TITLE
Make v0.38x visible in the docs menu

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,4 @@
 main      main        false
-v0.38.x   v0.38       false
 v0.34.x   v0.34       true
 v0.37.x   v0.37       true
+v0.38.x   v0.38       true


### PR DESCRIPTION
Make the v0.38 option visible in the dropdown menu and make it the default option so when users go to docs.cometbft.com the v0.38x content is displayed by default.