### PR TITLE
Prepare docs build for v1

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,5 @@
 main      main        false
+v1.x      v1          false
 v0.34.x   v0.34       true
 v0.37.x   v0.37       true
 v0.38.x   v0.38       true


### PR DESCRIPTION
This change:
1. Enables building the CometBFT docs from the `v1.x` branch in the CometBFT repo.
2. Will render the docs to <https://docs.cometbft.com/v1>
3. Does not yet display the `v1` version in the version selector dropdown.