### PR TITLE
docs: adding v1 branch to the website

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,5 @@
 main          main        false
+v1.x          v1.0        true
 v0.34.x       v0.34       true
 v0.37.x       v0.37       true
 v0.38.x       v0.38       true


### PR DESCRIPTION
closes: #91 

This PR adds the `v1.x` cometbft branch to the `VERSIONS` file so the content of the v1 branch is available on the website.  