### PR TITLE
make v1 the default option 

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,5 +1,5 @@
 main          main        false
-v1.x          v1.0        true
 v0.34.x       v0.34       true
 v0.37.x       v0.37       true
 v0.38.x       v0.38       true
+v1.x          v1.0        true


### PR DESCRIPTION
This changes the docs to version selector to use v1.0 as the default option 